### PR TITLE
Allow memory.Handler to encode `time.duration`

### DIFF
--- a/resource/testing/mem/mem.go
+++ b/resource/testing/mem/mem.go
@@ -29,6 +29,7 @@ func init() {
 	gob.Register([]interface{}{})
 	gob.Register(map[string]interface{}{})
 	gob.Register(time.Time{})
+	gob.Register(time.Duration(0))
 }
 
 // NewHandler creates an empty memory handler.


### PR DESCRIPTION
commit 3e9af551c0b8630ffb4fef7c31e9d235a4a72e6f (HEAD -> mem-allow-duration, origin/mem-allow-duration)
Author: Martin Mikalsen <martin.mikalsen@outlook.com>
Date:   Fri Jan 28 14:03:24 2022 +0100

    Allow memory.Handler to encode `time.duration`
